### PR TITLE
Fix signing usecase

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import {Keypair } from '@solana/web3.js';
+import {Keypair} from '@solana/web3.js';
 import React, {useState, useEffect} from 'react';
 import {
   BackHandler,
@@ -13,10 +13,15 @@ import MainScreen from './screens/MainScreen';
 import LoadingScreen from './screens/LoadingScreen';
 import AuthenticationScreen from './screens/AuthenticationScreen';
 import SignPayloadsScreen from './screens/SignPayloadsScreen';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
+import WalletProvider from './components/WalletProvider';
 
 function initMWA(url: string) {
-  NativeModules.WalletLib.createScenario("MobileWalletAdapterReactNative", url, (result, message) => {});
+  NativeModules.WalletLib.createScenario(
+    'MobileWalletAdapterReactNative',
+    url,
+    (result, message) => {},
+  );
 }
 
 const useLaunchURL = () => {
@@ -29,7 +34,10 @@ const useLaunchURL = () => {
       setUrl(initialUrl);
 
       // this should be dealt with elsewhere, but this is the only place where it works rn
-      if (initialUrl && initialUrl.startsWith("solana-wallet:/v1/associate/local")) {
+      if (
+        initialUrl &&
+        initialUrl.startsWith('solana-wallet:/v1/associate/local')
+      ) {
         initMWA(initialUrl);
       }
     };
@@ -61,19 +69,25 @@ export enum MobileWalletAdapterServiceEventType {
   SessionTerminated = 'SESSION_TERMINATED',
   LowPowerNoConnection = 'LOW_POWER_NO_CONNECTION',
   AuthorizeDapp = 'AUTHORIZE_DAPP',
-  ReauthorizeDapp = 'REAUTHORIZE_DAPP'
-};
+  ReauthorizeDapp = 'REAUTHORIZE_DAPP',
+}
 
 export default function App() {
   const {url: intentUrl} = useLaunchURL();
-  const {wallet} = useWallet()
   const [event, setEvent] = useState<any | null>(null);
   useEffect(() => {
-    const eventEmitter = new NativeEventEmitter(NativeModules.MwaWalletLibModule);
-    eventEmitter.removeAllListeners("MobileWalletAdapterServiceEvent");
-    eventEmitter.addListener("MobileWalletAdapterServiceEvent", (newEvent) => {
-      NativeModules.WalletLib.log("MWA Event: " + newEvent.type);
-      if (!(newEvent?.type === "SESSION_TERMINATED" && event?.type === "SESSION_TERMINATED")) {
+    const eventEmitter = new NativeEventEmitter(
+      NativeModules.MwaWalletLibModule,
+    );
+    eventEmitter.removeAllListeners('MobileWalletAdapterServiceEvent');
+    eventEmitter.addListener('MobileWalletAdapterServiceEvent', newEvent => {
+      NativeModules.WalletLib.log('MWA Event: ' + newEvent.type);
+      if (
+        !(
+          newEvent?.type === 'SESSION_TERMINATED' &&
+          event?.type === 'SESSION_TERMINATED'
+        )
+      ) {
         setEvent(newEvent);
       }
     });
@@ -81,39 +95,43 @@ export default function App() {
 
   useEffect(() => {
     // exit when MWA session ends
-    // it would be better if the app went to the background rather than fully exiting, but seems 
+    // it would be better if the app went to the background rather than fully exiting, but seems
     // this will need to be done in android. We can expose a method in the mwa module to navigate up
-    if (event?.type === "SESSION_TERMINATED") { 
+    if (event?.type === 'SESSION_TERMINATED') {
       setEvent(null);
-      setTimeout(() => {BackHandler.exitApp();}, 200);
+      setTimeout(() => {
+        BackHandler.exitApp();
+      }, 200);
     }
   }, [event]);
 
   function getComponent(event) {
-    switch(event?.type) {
+    switch (event?.type) {
       case MobileWalletAdapterServiceEventType.SignTransactions:
       case MobileWalletAdapterServiceEventType.SignMessages:
-        return <SignPayloadsScreen wallet={wallet} event={event} />;
+        return <SignPayloadsScreen event={event} />;
       case MobileWalletAdapterServiceEventType.AuthorizeDapp:
-        return <AuthenticationScreen wallet={wallet} />;
+        return <AuthenticationScreen />;
       default:
         return <LoadingScreen />;
     }
-
-    return <LoadingScreen />;
   }
 
-  const shouldRenderBottomsheet: boolean = intentUrl !== null && intentUrl.startsWith("solana-wallet:/v1/associate/local")
+  const shouldRenderBottomsheet: boolean =
+    intentUrl !== null &&
+    intentUrl.startsWith('solana-wallet:/v1/associate/local');
   return (
     <SafeAreaProvider>
-      <View style={shouldRenderBottomsheet ? styles.bottomSheet : {}}>
-        {/* TODO: should put the intent url somewhere else */
-          shouldRenderBottomsheet ?
-            getComponent(event) : <MainScreen />
-        }
-      </View>
+      <WalletProvider>
+        <View style={shouldRenderBottomsheet ? styles.bottomSheet : {}}>
+          {
+            /* TODO: should put the intent url somewhere else */
+            shouldRenderBottomsheet ? getComponent(event) : <MainScreen />
+          }
+        </View>
+      </WalletProvider>
     </SafeAreaProvider>
-    );
+  );
 }
 
 const styles = StyleSheet.create({

--- a/android/app/src/main/java/com/mobilewalletadapterreactnative/SolanaMobileWalletAdapterModule.kt
+++ b/android/app/src/main/java/com/mobilewalletadapterreactnative/SolanaMobileWalletAdapterModule.kt
@@ -106,11 +106,20 @@ class SolanaMobileWalletAdapterModule(val reactContext: ReactApplicationContext)
 
     @ReactMethod
     fun completeSignPayloadsRequest(signedPayloads: ReadableArray) {
-        Log.d(TAG, "completeSignPaylaodsRequest: signedPayloads = ")
+        // signedPayloads is an Array of Number Arrays, with each inner Array representing
+        // the bytes of a signed payload.
+        Log.d(TAG, "completeSignPayloadsRequest: signedPayloads = $signedPayloads")
         (request as? MobileWalletAdapterServiceRequest.SignPayloads)?.request?.let { signRequest ->
-            // temp
-            val signedPayloads = signRequest.payloads
-            signRequest.completeWithSignedPayloads(signedPayloads)
+            // Convert ReadableArray to Array of Number Arrays
+            val payloadNumArrays = Arguments.toList(signedPayloads) as List<List<Number>>
+
+            // Convert each Number Array into a ByteArray
+            val payloadByteArrays = payloadNumArrays.map { numArray ->
+                ByteArray(numArray.size) { numArray[it].toByte() }
+            }.toTypedArray()
+
+            Log.d(TAG, "signedPayload ByteArrays = $payloadByteArrays")
+            signRequest.completeWithSignedPayloads(payloadByteArrays)
         }
     }
 

--- a/android/app/src/main/java/com/mobilewalletadapterreactnative/SolanaMobileWalletAdapterModule.kt
+++ b/android/app/src/main/java/com/mobilewalletadapterreactnative/SolanaMobileWalletAdapterModule.kt
@@ -199,7 +199,7 @@ class SolanaMobileWalletAdapterModule(val reactContext: ReactApplicationContext)
         }
 
         override fun onReauthorizeRequest(request: ReauthorizeRequest) {
-            Log.i(TAG, "Reauthorization request: atuo completeing, DO NOT DO THIS IN PRODUCTION")
+            Log.i(TAG, "Reauthorization request: auto completing, DO NOT DO THIS IN PRODUCTION")
 //            this@SolanaMobileWalletAdapterModule.request =
 //                MobileWalletAdapterServiceRequest.ReauthorizeDapp(request)
             request.completeWithReauthorize()

--- a/components/WalletProvider.tsx
+++ b/components/WalletProvider.tsx
@@ -42,6 +42,8 @@ const WalletProvider: React.FC<WalletProviderProps> = ({children}) => {
 
   useEffect(() => {
     const generateKeypair = async () => {
+      // For testing purposes, we are storing the keypair in async-storage. This is unsafe
+      // and should not be replicated for production purposes.
       try {
         const storedKeypair = await AsyncStorage.getItem(ASYNC_STORAGE_KEY);
         let keypair: Keypair;

--- a/components/WalletProvider.tsx
+++ b/components/WalletProvider.tsx
@@ -1,0 +1,77 @@
+import React, {createContext, useContext, useState, useEffect} from 'react';
+import {Keypair} from '@solana/web3.js';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {NativeModules} from 'react-native';
+import {encode, decode} from 'bs58';
+
+interface WalletContextType {
+  wallet: Keypair | null;
+}
+
+const WalletContext = createContext<WalletContextType>({wallet: null});
+
+export const useWallet = () => {
+  return useContext(WalletContext);
+};
+
+type WalletProviderProps = {
+  children: React.ReactNode;
+};
+
+type EncodedKeypair = {
+  publicKeyBase58: string;
+  secretKeyBase58: string;
+};
+
+const ASYNC_STORAGE_KEY: string = '@reactnativefakewallet_keypair_key';
+
+const encodeKeypair = (keypair: Keypair): EncodedKeypair => {
+  return {
+    publicKeyBase58: keypair.publicKey.toBase58(),
+    secretKeyBase58: encode(keypair.secretKey),
+  };
+};
+
+const decodeKeypair = (keypair: EncodedKeypair): Keypair => {
+  var secretKey: Uint8Array = decode(keypair.secretKeyBase58);
+  return Keypair.fromSecretKey(secretKey);
+};
+
+const WalletProvider: React.FC<WalletProviderProps> = ({children}) => {
+  const [keypair, setKeypair] = useState<Keypair | null>(null);
+
+  useEffect(() => {
+    const generateKeypair = async () => {
+      try {
+        const storedKeypair = await AsyncStorage.getItem(ASYNC_STORAGE_KEY);
+        let keypair: Keypair;
+        if (storedKeypair !== null) {
+          const encodedKeypair: EncodedKeypair = JSON.parse(storedKeypair);
+          keypair = decodeKeypair(encodedKeypair);
+          console.log('Keypair retrieved: ' + keypair.publicKey);
+        } else {
+          // Generate new keypair
+          keypair = await Keypair.generate();
+          console.log('Keypair generated: ' + keypair.publicKey);
+          await AsyncStorage.setItem(
+            ASYNC_STORAGE_KEY,
+            JSON.stringify(encodeKeypair(keypair)),
+          );
+        }
+        setKeypair(keypair);
+      } catch (error) {
+        NativeModules.WalletLib.log('Error retrieving keypair');
+      }
+    };
+
+    generateKeypair();
+  }, []);
+
+  return (
+    <WalletContext.Provider value={{wallet: keypair}}>
+      {children}
+    </WalletContext.Provider>
+  );
+};
+
+export default WalletProvider;

--- a/package.json
+++ b/package.json
@@ -10,16 +10,17 @@
     "test": "jest"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.18.1",
     "@solana/wallet-adapter-base": "^0.9.17",
     "@solana/wallet-adapter-react": "^0.15.7",
     "@solana/web3.js": "^1.58.0",
+    "bs58": "^5.0.0",
+    "localstorage-polyfill": "^1.0.1",
     "react": "18.2.0",
     "react-native": "0.71.4",
-    "react-native-paper": "^5.0.0-rc.5",
-    "react-native-safe-area-context": "^4.5.0",
     "react-native-get-random-values": "^1.8.0",
-    "localstorage-polyfill": "^1.0.1"
-
+    "react-native-paper": "^5.0.0-rc.5",
+    "react-native-safe-area-context": "^4.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/screens/AuthenticationScreen.tsx
+++ b/screens/AuthenticationScreen.tsx
@@ -1,70 +1,63 @@
-import { Keypair } from '@solana/web3.js';
-import React from 'react';
+import React, {useEffect} from 'react';
 import {NativeModules, Platform, StyleSheet, View} from 'react-native';
 import {Button, Divider, Text} from 'react-native-paper';
+import {useWallet} from '../components/WalletProvider';
 
 import FadeInView from './../components/FadeInView';
 
 const SolanaMobileWalletAdapter =
-    Platform.OS === 'android' && NativeModules.WalletLib
-        ? NativeModules.WalletLib
-        : new Proxy(
-              {},
-              {
-                  get() {
-                      throw new Error(
-                          Platform.OS !== 'android'
-                              ? 'The package `solana-mobile-wallet-adapter-protocol` is only compatible with React Native Android'
-                              : 'Failed to link the `solana-mobile-wallet-adapter-protocol` package. Please make sure the package is installed correctly and all dependencies are up to date.',
-                      );
-                  },
-              },
-          );
+  Platform.OS === 'android' && NativeModules.WalletLib
+    ? NativeModules.WalletLib
+    : new Proxy(
+        {},
+        {
+          get() {
+            throw new Error(
+              Platform.OS !== 'android'
+                ? 'The package `solana-mobile-wallet-adapter-protocol` is only compatible with React Native Android'
+                : 'Failed to link the `solana-mobile-wallet-adapter-protocol` package. Please make sure the package is installed correctly and all dependencies are up to date.',
+            );
+          },
+        },
+      );
 
-type Props = Readonly<{
-  wallet: Keypair | null;
-}>;
-
-export default function AuthenticationScreen({wallet}: Props) {
+export default function AuthenticationScreen() {
   const [visible, setIsVisible] = React.useState(true);
-  if (wallet === null) {
-    return <FadeInView style={styles.container} shown={true}>
-      <Text variant="bodyLarge">
-        Wallet not found
-      </Text>
-    </FadeInView>
+  const {wallet} = useWallet();
+
+  // Assert that wallet is not null
+  if (!wallet) {
+    throw new Error('Wallet is null or undefined');
   }
 
-
-  // there has got to be a better way to reset the state, 
-  // so it alwyas shows on render. I am react n00b 
-  React.useEffect(() => {
+  // there has got to be a better way to reset the state,
+  // so it alwyas shows on render. I am react n00b
+  useEffect(() => {
     setIsVisible(true);
   });
-  
+
   return (
-      <FadeInView style={styles.container} shown={visible}>
-        <Text variant="bodyLarge">
-          Authorize The Things
-        </Text>
-        <Divider style={styles.spacer} />
-        <View style={styles.buttonGroup}>
-          <Button
-            style={styles.actionButton}
-            onPress = {() => {
-              SolanaMobileWalletAdapter.authorizeDapp(Array.from(wallet.publicKey.toBytes()));
-              setIsVisible(false);
-            }}
-            mode="contained">
-            Authorize
-          </Button>
-          <Button
-            style={styles.actionButton}
-            mode="outlined">
-            Decline
-          </Button>
-        </View>
-      </FadeInView>
+    <FadeInView style={styles.container} shown={visible}>
+      <Text variant="bodyLarge">Authorize The Things</Text>
+      <Divider style={styles.spacer} />
+      <View style={styles.buttonGroup}>
+        <Button
+          style={styles.actionButton}
+          onPress={() => {
+            console.log('publickey in bytes: ' + wallet.publicKey.toBytes());
+            SolanaMobileWalletAdapter.authorizeDapp(
+              Array.from(wallet.publicKey.toBytes()),
+            );
+            setIsVisible(false);
+          }}
+          mode="contained">
+          Authorize
+        </Button>
+        <Button style={styles.actionButton} mode="outlined">
+          Decline
+        </Button>
+      </View>
+    </FadeInView>
   );
 }
 
@@ -91,5 +84,5 @@ const styles = StyleSheet.create({
   actionButton: {
     flex: 1,
     marginEnd: 8,
-  }
+  },
 });

--- a/screens/AuthenticationScreen.tsx
+++ b/screens/AuthenticationScreen.tsx
@@ -44,7 +44,6 @@ export default function AuthenticationScreen() {
         <Button
           style={styles.actionButton}
           onPress={() => {
-            console.log('publickey in bytes: ' + wallet.publicKey.toBytes());
             SolanaMobileWalletAdapter.authorizeDapp(
               Array.from(wallet.publicKey.toBytes()),
             );

--- a/screens/MainScreen.tsx
+++ b/screens/MainScreen.tsx
@@ -1,6 +1,23 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {Keypair} from '@solana/web3.js';
 import React from 'react';
 import {View} from 'react-native';
-import {Appbar, Text} from 'react-native-paper';
+import {Appbar, Button, Text} from 'react-native-paper';
+import {encode} from 'bs58';
+
+const ASYNC_STORAGE_KEY: string = '@reactnativefakewallet_keypair_key';
+
+type EncodedKeypair = {
+  publicKeyBase58: string;
+  secretKeyBase58: string;
+};
+
+const encodeKeypair = (keypair: Keypair): EncodedKeypair => {
+  return {
+    publicKeyBase58: keypair.publicKey.toBase58(),
+    secretKeyBase58: encode(keypair.secretKey),
+  };
+};
 
 export default function MainScreen() {
   return (
@@ -15,6 +32,17 @@ export default function MainScreen() {
           alignItems: 'center',
         }}>
         <Text>I'm a Wallet!</Text>
+        <Button
+          onPress={async () => {
+            const keypair = await Keypair.generate();
+            console.log('Keypair reset to: ' + keypair.publicKey);
+            await AsyncStorage.setItem(
+              ASYNC_STORAGE_KEY,
+              JSON.stringify(encodeKeypair(keypair)),
+            );
+          }}>
+          Reset wallet keypair
+        </Button>
       </View>
     </>
   );

--- a/screens/SignPayloadsScreen.tsx
+++ b/screens/SignPayloadsScreen.tsx
@@ -43,7 +43,6 @@ const signPayload = (wallet: Keypair, event: SignPayloadEvent) => {
   let signedPayloads;
   switch (event.type) {
     case MobileWalletAdapterServiceEventType.SignTransactions:
-      console.log(event.payloads);
       signedPayloads = event.payloads.map((numArray, index) => {
         try {
           return Array.from(
@@ -71,12 +70,10 @@ const signPayload = (wallet: Keypair, event: SignPayloadEvent) => {
 
   // If all valid, then call complete request
   if (!valid.includes(false)) {
-    console.log('complete case');
     SolanaMobileWalletAdapter.completeSignPayloadsRequest(
       Array.from(signedPayloads),
     );
   } else {
-    console.log('invalid case');
     SolanaMobileWalletAdapter.completeWithInvalidPayloads(valid);
   }
 };

--- a/screens/SignPayloadsScreen.tsx
+++ b/screens/SignPayloadsScreen.tsx
@@ -1,114 +1,122 @@
-import { Keypair } from '@solana/web3.js';
+import {Keypair} from '@solana/web3.js';
 import React, {useState, useEffect} from 'react';
-import {BackHandler, NativeModules, Platform, StyleSheet, View} from 'react-native';
+import {NativeModules, Platform, StyleSheet, View} from 'react-native';
 import {Button, Divider, Text} from 'react-native-paper';
-import { MobileWalletAdapterServiceEventType } from '../App';
-import { SolanaSigningUseCase } from '../utils/SolanaSigningUseCase';
+import {MobileWalletAdapterServiceEventType} from '../App';
+import {SolanaSigningUseCase} from '../utils/SolanaSigningUseCase';
+import {useWallet} from '../components/WalletProvider';
 
 import FadeInView from './../components/FadeInView';
 
 const SolanaMobileWalletAdapter =
-    Platform.OS === 'android' && NativeModules.WalletLib
-        ? NativeModules.WalletLib
-        : new Proxy(
-              {},
-              {
-                  get() {
-                      throw new Error(
-                          Platform.OS !== 'android'
-                              ? 'The package `solana-mobile-wallet-adapter-protocol` is only compatible with React Native Android'
-                              : 'Failed to link the `solana-mobile-wallet-adapter-protocol` package. Please make sure the package is installed correctly and all dependencies are up to date.'      
-                      );
-                  },
-              },
-          );
+  Platform.OS === 'android' && NativeModules.WalletLib
+    ? NativeModules.WalletLib
+    : new Proxy(
+        {},
+        {
+          get() {
+            throw new Error(
+              Platform.OS !== 'android'
+                ? 'The package `solana-mobile-wallet-adapter-protocol` is only compatible with React Native Android'
+                : 'Failed to link the `solana-mobile-wallet-adapter-protocol` package. Please make sure the package is installed correctly and all dependencies are up to date.',
+            );
+          },
+        },
+      );
 
 type SignPayloadEvent = {
-  type: MobileWalletAdapterServiceEventType.SignMessages | MobileWalletAdapterServiceEventType.SignTransactions;
+  type:
+    | MobileWalletAdapterServiceEventType.SignMessages
+    | MobileWalletAdapterServiceEventType.SignTransactions;
   payloads: number[][];
-}
+};
 
 type Props = Readonly<{
   event: SignPayloadEvent;
-  wallet: Keypair | null;
 }>;
 
-// this view is basically the same as AuthenticationScreen. 
-// Should either combine them or pull common code to base abstraction
-export default function SignPayloadsScreen({event, wallet}: Props) {
-  if (wallet === null) {
-    return <FadeInView style={styles.container} shown={true}>
-      <Text variant="bodyLarge">
-        Wallet not found
-      </Text>
-    </FadeInView>
+const signPayload = (wallet: Keypair, event: SignPayloadEvent) => {
+  const valid: boolean[] = event.payloads.map(_ => {
+    return true;
+  });
+
+  let signedPayloads;
+  switch (event.type) {
+    case MobileWalletAdapterServiceEventType.SignTransactions:
+      console.log(event.payloads);
+      signedPayloads = event.payloads.map((numArray, index) => {
+        try {
+          return Array.from(
+            SolanaSigningUseCase.signTransaction(
+              new Uint8Array(numArray),
+              wallet,
+            ),
+          );
+        } catch (e) {
+          NativeModules.WalletLib.log(
+            `Transaction ${index} is not a valid Solana transaction`,
+          );
+          valid[index] = false;
+          return new Uint8Array([]);
+        }
+      });
+      break;
+    case MobileWalletAdapterServiceEventType.SignMessages:
+      signedPayloads = event.payloads.map(numArray => {
+        return Array.from(
+          SolanaSigningUseCase.signMessage(new Uint8Array(numArray), wallet),
+        );
+      });
   }
 
-  const [visible, setIsVisible] = useState(true);
+  // If all valid, then call complete request
+  if (!valid.includes(false)) {
+    console.log('complete case');
+    SolanaMobileWalletAdapter.completeSignPayloadsRequest(
+      Array.from(signedPayloads),
+    );
+  } else {
+    console.log('invalid case');
+    SolanaMobileWalletAdapter.completeWithInvalidPayloads(valid);
+  }
+};
 
-  // there has got to be a better way to reset the state, 
-  // so it alwyas shows on render. I am react n00b 
+// this view is basically the same as AuthenticationScreen.
+// Should either combine them or pull common code to base abstraction
+export default function SignPayloadsScreen({event}: Props) {
+  const [visible, setIsVisible] = useState(true);
+  const {wallet} = useWallet();
+
+  // Assert that wallet is not null
+  if (!wallet) {
+    throw new Error('Wallet is null or undefined');
+  }
+
+  // there has got to be a better way to reset the state,
+  // so it alwyas shows on render. I am react n00b
   useEffect(() => {
     setIsVisible(true);
   });
 
-
   return (
-      <FadeInView style={styles.container} shown={visible}>
-        <Text variant="bodyLarge">
-          Sign The Transaction Things
-        </Text>
-        <Divider style={styles.spacer} />
-        <View style={styles.buttonGroup}>
-          <Button
-            style={styles.actionButton}
-            onPress = {() => {
-              
-              // TODO: move this code into a separate method
-              const valid: boolean[] = event.payloads.map((numArray) => {
-                return true
-              })
-
-              let signedPayloads;
-              switch (event.type) {
-                case MobileWalletAdapterServiceEventType.SignTransactions:
-                  signedPayloads = event.payloads.map((numArray, index) => {
-                    try {
-                      return Array.from(SolanaSigningUseCase.signTransaction(new Uint8Array(numArray), wallet))
-                    } catch (e) {
-                      NativeModules.WalletLib.log(`Transaction ${index} is not a valid Solana transaction`);
-                      valid[index] = false
-                      return new Uint8Array([])
-                    }
-                  });
-                  break;
-                case MobileWalletAdapterServiceEventType.SignMessages:
-                  signedPayloads = event.payloads.map((numArray) => {
-                    return Array.from(SolanaSigningUseCase.signMessage(new Uint8Array(numArray), wallet))
-                  });
-              }
-
-              // If all valid, then call complete request
-              if (!valid.includes(false)) {
-                console.log("complete case")
-                SolanaMobileWalletAdapter.completeSignPayloadsRequest(Array.from(signedPayloads));
-              } else {
-                console.log("invalid case")
-                SolanaMobileWalletAdapter.completeWithInvalidPayloads(valid);
-              }
-              
-              setIsVisible(false);
-            }}
-            mode="contained">
-            Sign
-          </Button>
-          <Button
-            style={styles.actionButton}
-            mode="outlined">
-            Reject
-          </Button>
-        </View>
-      </FadeInView>
+    <FadeInView style={styles.container} shown={visible}>
+      <Text variant="bodyLarge">Sign The Transaction Things</Text>
+      <Divider style={styles.spacer} />
+      <View style={styles.buttonGroup}>
+        <Button
+          style={styles.actionButton}
+          onPress={() => {
+            signPayload(wallet, event);
+            setIsVisible(false);
+          }}
+          mode="contained">
+          Sign
+        </Button>
+        <Button style={styles.actionButton} mode="outlined">
+          Reject
+        </Button>
+      </View>
+    </FadeInView>
   );
 }
 
@@ -135,5 +143,5 @@ const styles = StyleSheet.create({
   actionButton: {
     flex: 1,
     marginEnd: 8,
-  }
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,6 +1471,13 @@
   dependencies:
     merge-options "^3.0.4"
 
+"@react-native-async-storage/async-storage@^1.18.1":
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.18.1.tgz#b1aea4f07fb1dba3325b857b770671517ddab221"
+  integrity sha512-70aFW8fVCKl+oA1AKPFDpE6s4t9pulj2QeLX+MabEmzfT3urd/3cckv45WJvtocdoIH/oXA3Y+YcCRJCcNa8mA==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cli-clean@^10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-10.1.1.tgz#4c73ce93a63a24d70c0089d4025daac8184ff504"


### PR DESCRIPTION
To fully test the signing usecase, I needed to add several things:

**Persistent Keypair storage with react-native-async-storage**
- Previously, the keypair was randomly generated on every instantiation of MainActivity, so every time a bottom sheet popped up, we would be generating a new keypair. 
- Now, instead of generating a new Keypair, I implemented `WalletProvider` that caches the generated keypair with async-storage and re-uses for each request.
- This solution is for demo/test purposes only and should not be considered a production-ready storage solution.

**Signing use case bug**
- There was a bug where the `ReadableArray` passed to the kotlin native module wasn't converted into a `Array<ByteArray>`
